### PR TITLE
Added requests libary to base requirements

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,4 +13,5 @@ django-bootstrap-form>=3.1,<3.2
 croniter==0.3.4
 GitPython
 gevent-socketio>=0.3.6,<0.4
+requests==2.3.0
 virtualenv>=1.11.6,<1.12


### PR DESCRIPTION
Requests HTTP library is used by web hooks. Fixes "django.core.exceptions.ImproperlyConfigured: ImportError fabric_bolt.web_hooks: No module named requests" error after installations.
