### PR TITLE
Changed SchemelessURLValidator to full_domain_validator on hosts/models....

### DIFF
--- a/fabric_bolt/hosts/migrations/0001_initial.py
+++ b/fabric_bolt/hosts/migrations/0001_initial.py
@@ -15,8 +15,8 @@ class Migration(migrations.Migration):
             name='Host',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('name', models.CharField(help_text=b'DNS name or IP address', max_length=255, validators=[fabric_bolt.hosts.models.SchemelessURLValidator()])),
-                ('alias', models.CharField(blank=True, max_length=255, null=True, help_text=b'Human readable value (optional)', validators=[fabric_bolt.hosts.models.SchemelessURLValidator()])),
+                ('name', models.CharField(help_text=b'DNS name or IP address', max_length=255, validators=[fabric_bolt.hosts.models.full_domain_validator])),
+                ('alias', models.CharField(blank=True, max_length=255, null=True, help_text=b'Human readable value (optional)')),
             ],
             options={
             },

--- a/fabric_bolt/hosts/models.py
+++ b/fabric_bolt/hosts/models.py
@@ -3,6 +3,16 @@ import re
 from django.db import models
 from django.core.validators import URLValidator
 
+class SchemelessURLValidator(URLValidator):
+    """Old valitador, keeping to migrations work"""
+    regex = re.compile(
+    r'(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|'  # domain...
+    r'localhost|'  # localhost...
+    r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}|'  # ...or ipv4
+    r'\[?[A-F0-9]*:[A-F0-9:]+\]?)'  # ...or ipv6
+    r'(?::\d+)?'  # optional port
+    r'(?:/?|[/?]\S+)$', re.IGNORECASE)
+
 def full_domain_validator(hostname):
     """
     Fully validates a domain name as compilant with the standard rules:


### PR DESCRIPTION
URLValidator isn't working as expected on Django 1.7, so I used this function http://stackoverflow.com/questions/17821400/regex-match-for-domain-name-in-django-model(full_domain_validator) and I was able to add a host using hostname and IP address successfully .
