### PR TITLE
Added a project option 'link_repo_env' to link project against existing python virtualenv

### DIFF
--- a/fabric_bolt/projects/forms.py
+++ b/fabric_bolt/projects/forms.py
@@ -18,6 +18,7 @@ class ProjectCreateForm(forms.ModelForm):
             'name',
             'description',
             'use_repo_fabfile',
+            'link_repo_env',
             'repo_url',
             'fabfile_requirements',
         ]
@@ -28,6 +29,7 @@ class ProjectCreateForm(forms.ModelForm):
             'name',
             'description',
             'use_repo_fabfile',
+            'link_repo_env',
             'repo_url',
             'fabfile_requirements',
             ButtonHolder(

--- a/fabric_bolt/projects/migrations/0001_initial.py
+++ b/fabric_bolt/projects/migrations/0001_initial.py
@@ -63,6 +63,7 @@ class Migration(migrations.Migration):
                 ('name', models.CharField(max_length=255)),
                 ('description', models.TextField(null=True, blank=True)),
                 ('use_repo_fabfile', models.BooleanField(default=False, help_text=b'If no, use the default fabfile.', verbose_name=b"Use repo's fabfile?")),
+                ('link_repo_env', models.BooleanField(default=False, help_text=b'If no, create new virtual environment.', verbose_name=b"Link repo's environment?")),
                 ('repo_url', models.CharField(help_text=b'Currently only git repos are supported.', max_length=200, null=True, blank=True)),
                 ('fabfile_requirements', models.TextField(help_text=b'Pip requirements to install for fabfile. Enter one requirement per line.', null=True, blank=True)),
             ],

--- a/fabric_bolt/projects/models.py
+++ b/fabric_bolt/projects/models.py
@@ -20,6 +20,8 @@ class Project(TrackingFields):
 
     use_repo_fabfile = models.BooleanField(default=False, verbose_name='Use repo\'s fabfile?',
                                            help_text='If no, use the default fabfile.')
+    link_repo_env = models.BooleanField(default=False, verbose_name='Link repo\'s environment?',
+                                           help_text='If no, create a new virtual environment.')
     repo_url = models.CharField(max_length=200, null=True, blank=True, help_text='Currently only git repos are supported.')
     fabfile_requirements = models.TextField(null=True, blank=True, help_text='Pip requirements to install for fabfile. '
                                                                              'Enter one requirement per line.')

--- a/fabric_bolt/projects/util.py
+++ b/fabric_bolt/projects/util.py
@@ -38,6 +38,12 @@ def update_project_git(project, cache_dir, repo_dir):
         )
 
 
+def setup_link_env_if_needed(repo_dir):
+    env_dir = os.path.join(repo_dir, 'env')
+    if not os.path.exists(env_dir):
+        os.symlink(os.environ.get('VIRTUAL_ENV'), env_dir)
+
+
 def setup_virtual_env_if_needed(repo_dir):
     env_dir = os.path.join(repo_dir, 'env')
     if not os.path.exists(env_dir):
@@ -63,7 +69,10 @@ def get_fabfile_path(project):
         repo_dir = os.path.join(cache_dir, slugify(project.name))
 
         update_project_git(project, cache_dir, repo_dir)
-        setup_virtual_env_if_needed(repo_dir)
+        if project.link_repo_env:
+            setup_link_env_if_needed(repo_dir)
+        else:
+            setup_virtual_env_if_needed(repo_dir)
         activate_loc = os.path.join(repo_dir, 'env', 'bin', 'activate')
 
         update_project_requirements(project, repo_dir, activate_loc)

--- a/fabric_bolt/projects/views.py
+++ b/fabric_bolt/projects/views.py
@@ -89,6 +89,7 @@ class ProjectCopy(MultipleGroupRequiredMixin, CreateView):
             initial.update({'name': '%s copy' % self.copy_object.name,
                             'description': self.copy_object.description,
                             'use_repo_fabfile': self.copy_object.use_repo_fabfile,
+                            'link_repo_env': self.copy_object.link_repo_env,
                             'fabfile_requirements': self.copy_object.fabfile_requirements,
                             'repo_url': self.copy_object.repo_url})
         return initial

--- a/fabric_bolt/web_hooks/migrations/0001_initial.py
+++ b/fabric_bolt/web_hooks/migrations/0001_initial.py
@@ -37,7 +37,8 @@ class Migration(SchemaMigration):
             'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
             'repo_url': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
             'type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['projects.ProjectType']", 'null': 'True', 'blank': 'True'}),
-            'use_repo_fabfile': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+            'use_repo_fabfile': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'link_repo_env': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
         },
         u'projects.projecttype': {
             'Meta': {'object_name': 'ProjectType'},


### PR DESCRIPTION
In some cases we simply wanted the project to use the existing virtual environment instead of generating a new one.

Thus I added a project option 'link_repo_env' to link project against existing python virtualenv instead of completely generating a new environment.

Not sure if you like this option or not, but figured I'd tender it to the community anyway.