### PR TITLE
Fix fabfile importing other tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ core.db
 
 # Distribution / Packaging #
 ###############################
+venv/
 build/
 dist/
 *.egg-info/

--- a/fabric_bolt/projects/urls.py
+++ b/fabric_bolt/projects/urls.py
@@ -18,7 +18,7 @@ urlpatterns = patterns('',
     url(r'^configuration/update/(?P<pk>\w+)/$', views.ProjectConfigurationUpdate.as_view(), name='projects_configuration_update'),
     url(r'^configuration/delete/(?P<pk>\w+)/$', views.ProjectConfigurationDelete.as_view(), name='projects_configuration_delete'),
 
-    url(r'^stage/(?P<pk>\d+)/deployment/(?P<task_name>\w+)/$', views.DeploymentCreate.as_view(), name='projects_deployment_create'),
+    url(r'^stage/(?P<pk>\d+)/deployment/(?P<task_name>\w+((?:\.\w+)+)?)/$', views.DeploymentCreate.as_view(), name='projects_deployment_create'),
     url(r'^deployment/view/(?P<pk>\d+)', views.DeploymentDetail.as_view(), name='projects_deployment_detail'),
     url(r'^deployment/output/(?P<pk>\d+)', views.DeploymentOutputStream.as_view(), name='projects_deployment_output'),
 


### PR DESCRIPTION
# The Problem
If you're using a fabfile with imports, fabric-bolt was unable to load the tasks, and threw the following error:

```python
Internal Server Error: /projects/2/stage/get_tasks_ajax/3/
Traceback (most recent call last):
  File "/var/www/fabric-bolt/venv/lib/python2.7/site-packages/django/core/handlers/base.py", line 137, in get_response
    response = response.render()
  File "/var/www/fabric-bolt/venv/lib/python2.7/site-packages/django/template/response.py", line 103, in render
    self.content = self.rendered_content
  File "/var/www/fabric-bolt/venv/lib/python2.7/site-packages/django/template/response.py", line 80, in rendered_content
    content = template.render(context)
  File "/var/www/fabric-bolt/venv/lib/python2.7/site-packages/django/template/base.py", line 148, in render
    return self._render(context)
  File "/var/www/fabric-bolt/venv/lib/python2.7/site-packages/django/test/utils.py", line 88, in instrumented_test_render
    return self.nodelist.render(context)
  File "/var/www/fabric-bolt/venv/lib/python2.7/site-packages/django/template/base.py", line 844, in render
    bit = self.render_node(node, context)
  File "/var/www/fabric-bolt/venv/lib/python2.7/site-packages/django/template/debug.py", line 80, in render_node
    return node.render(context)
  File "/var/www/fabric-bolt/venv/lib/python2.7/site-packages/django/template/defaulttags.py", line 201, in render
    nodelist.append(node.render(context))
  File "/var/www/fabric-bolt/venv/lib/python2.7/site-packages/django/template/defaulttags.py", line 458, in render
    six.reraise(*exc_info)
  File "/var/www/fabric-bolt/venv/lib/python2.7/site-packages/django/template/defaulttags.py", line 444, in render
    url = reverse(view_name, args=args, kwargs=kwargs, current_app=context.current_app)
  File "/var/www/fabric-bolt/venv/lib/python2.7/site-packages/django/core/urlresolvers.py", line 551, in reverse
    return iri_to_uri(resolver._reverse_with_prefix(view, prefix, *args, **kwargs))
  File "/var/www/fabric-bolt/venv/lib/python2.7/site-packages/django/core/urlresolvers.py", line 468, in _reverse_with_prefix
    (lookup_view_s, args, kwargs, len(patterns), patterns))
NoReverseMatch: Reverse for 'projects_deployment_create' with arguments '(3, 'test.other_task')' and keyword arguments '{}' not found. 1 pattern(s) tried: ['projects/stage/(?P<pk>\\d+)/deployment/(?P<task_name>\\w+)/$']
[29/Jan/2015 15:53:07] "GET /projects/2/stage/get_tasks_ajax/3/ HTTP/1.1" 500 15058
```

Example fabfile structure:
```
fabfile/
    __init__.py
    test.py
```

# The Solution
Adjust the regex for the projects_deployment_create URL to optionally match a ".", followed by characters. Example "task.thing".

Travis tests passing.
[![Build Status](https://travis-ci.org/RyanFolsom/fabric-bolt.svg?branch=support-python-modules)](https://travis-ci.org/RyanFolsom/fabric-bolt)