### PR TITLE
Console style

### DIFF
--- a/fabric_bolt/core/static/css/main.css
+++ b/fabric_bolt/core/static/css/main.css
@@ -7,7 +7,16 @@
   color: #c8c8c8;
   padding: 20px;
   cursor: text;
-  overflow: auto;
+}
+#deployment_output .outputcontainer {
+  width: 100%;
+  height: 100%;
+  background: none;
+  border: none;
+  color: #c8c8c8;
+  overflow-y: scroll;
+  font-size: 14px;
+  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
 }
 .output {
   color:white;

--- a/fabric_bolt/core/static/css/main.css
+++ b/fabric_bolt/core/static/css/main.css
@@ -7,14 +7,24 @@
   color: #c8c8c8;
   padding: 20px;
   cursor: text;
+  overflow: auto;
 }
-#deployment_output pre {
-  width: 100%;
-  height: 100%;
-  background: none;
-  border: none;
-  color: #c8c8c8;
-  overflow-y: scroll;
+.output {
+  color:white;
   font-size: 14px;
   font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+}
+.output li {
+  list-style:none;
+  background-image:none;
+  background-repeat:none;
+  background-position:0; 
+}
+.outputred {
+  color:red !important;
+  padding-left:0;
+}
+.outputgreen {
+  color:green !important;
+  padding-left:0;
 }

--- a/fabric_bolt/core/static/css/main.less
+++ b/fabric_bolt/core/static/css/main.less
@@ -11,7 +11,7 @@
   cursor: text;
 }
 
-#deployment_output pre {
+#deployment_output outputcontainer {
   width:100%;
   height:100%;
   background:none;

--- a/fabric_bolt/projects/forms.py
+++ b/fabric_bolt/projects/forms.py
@@ -18,6 +18,7 @@ class ProjectCreateForm(forms.ModelForm):
             'name',
             'description',
             'use_repo_fabfile',
+            'link_repo_env',
             'repo_url',
             'fabfile_requirements',
         ]
@@ -28,6 +29,7 @@ class ProjectCreateForm(forms.ModelForm):
             'name',
             'description',
             'use_repo_fabfile',
+            'link_repo_env',
             'repo_url',
             'fabfile_requirements',
             ButtonHolder(

--- a/fabric_bolt/projects/migrations/0001_initial.py
+++ b/fabric_bolt/projects/migrations/0001_initial.py
@@ -63,6 +63,7 @@ class Migration(migrations.Migration):
                 ('name', models.CharField(max_length=255)),
                 ('description', models.TextField(null=True, blank=True)),
                 ('use_repo_fabfile', models.BooleanField(default=False, help_text=b'If no, use the default fabfile.', verbose_name=b"Use repo's fabfile?")),
+                ('link_repo_env', models.BooleanField(default=False, help_text=b'If no, create new virtual environment.', verbose_name=b"Link repo's environment?")),
                 ('repo_url', models.CharField(help_text=b'Currently only git repos are supported.', max_length=200, null=True, blank=True)),
                 ('fabfile_requirements', models.TextField(help_text=b'Pip requirements to install for fabfile. Enter one requirement per line.', null=True, blank=True)),
             ],

--- a/fabric_bolt/projects/models.py
+++ b/fabric_bolt/projects/models.py
@@ -20,6 +20,8 @@ class Project(TrackingFields):
 
     use_repo_fabfile = models.BooleanField(default=False, verbose_name='Use repo\'s fabfile?',
                                            help_text='If no, use the default fabfile.')
+    link_repo_env = models.BooleanField(default=False, verbose_name='Link repo\'s environment?',
+                                           help_text='If no, create a new virtual environment.')
     repo_url = models.CharField(max_length=200, null=True, blank=True, help_text='Currently only git repos are supported.')
     fabfile_requirements = models.TextField(null=True, blank=True, help_text='Pip requirements to install for fabfile. '
                                                                              'Enter one requirement per line.')

--- a/fabric_bolt/projects/static/projects/js/deployment.js
+++ b/fabric_bolt/projects/static/projects/js/deployment.js
@@ -24,6 +24,6 @@ $(function(){
 
 
     }else{
-        $('#deployment_output pre').scrollTop($('#deployment_output pre')[0].scrollHeight);
+        $('#deployment_output .outputcontainer').scrollTop($('#deployment_output .outputcontainer')[0].scrollHeight);
     }
 });

--- a/fabric_bolt/projects/static/projects/js/deployment_socketio.js
+++ b/fabric_bolt/projects/static/projects/js/deployment_socketio.js
@@ -12,7 +12,7 @@ $(function(){
 
         socket.on('output', function (data) {
             if(data.status == 'pending'){
-                $('#deployment_output pre').append(data.lines).scrollTop($('#deployment_output pre')[0].scrollHeight);
+                $('#deployment_output .outputcontainer').append(data.lines).scrollTop($('#deployment_output .outputcontainer')[0].scrollHeight);
             }else{
                 socket.disconnect();
                 if(data.status == 'failed'){
@@ -31,12 +31,12 @@ $(function(){
                 var text = $(this).val();
                 $(this).val('');
                 socket.emit('input', text);
-                $('#deployment_output pre').append('\n');
+                $('#deployment_output .outputcontainer').append('\n');
             }
         });
 
 
     }else{
-        $('#deployment_output pre').scrollTop($('#deployment_output pre')[0].scrollHeight);
+        $('#deployment_output .outputcontainer').scrollTop($('#deployment_output .outputcontainer')[0].scrollHeight);
     }
 });

--- a/fabric_bolt/projects/templates/projects/deployment_detail.html
+++ b/fabric_bolt/projects/templates/projects/deployment_detail.html
@@ -57,7 +57,7 @@
             {% if object.status == object.PENDING %}
                 <iframe src="{% url 'projects_deployment_output' object.pk %}" id="deployment_output"></iframe>
             {% else %}
-                <div id="deployment_output"><ul class="output">{{ object.output|safe }}</ul></div>
+                <div id="deployment_output"><div class="outputcontainer"><ul class="output">{{ object.output|safe }}</ul></div></div>
             {% endif %}
         {% endblock %}
     </div>

--- a/fabric_bolt/projects/templates/projects/deployment_detail.html
+++ b/fabric_bolt/projects/templates/projects/deployment_detail.html
@@ -57,7 +57,7 @@
             {% if object.status == object.PENDING %}
                 <iframe src="{% url 'projects_deployment_output' object.pk %}" id="deployment_output"></iframe>
             {% else %}
-                <div id="deployment_output"><pre class="prettyprint">{{ object.output }}</pre></div>
+                <div id="deployment_output"><ul class="output">{{ object.output|safe }}</ul></div>
             {% endif %}
         {% endblock %}
     </div>
@@ -67,6 +67,15 @@
         <script>
             var deployment_pending = {% if object.status == object.PENDING %}true{% else %}false{% endif %};
             var deployment_id = {{ object.pk }};
+            // Add parent CSS link to deployment iframe
+            $(document).ready(function(){
+                $('#deployment_output').load(function(){
+                    $('#deployment_output')
+                        .contents().find("head")
+                        .append($('<link rel="stylesheet" type="text/css" href="/static/css/main.css">')
+                    );
+                });
+            });
          </script>
         {% block deployment_scripts %}
             <script src="{% static 'projects/js/deployment.js' %}"></script>

--- a/fabric_bolt/projects/templates/projects/deployment_detail_socketio.html
+++ b/fabric_bolt/projects/templates/projects/deployment_detail_socketio.html
@@ -6,7 +6,7 @@
         <div id="deployment_output"><pre class="prettyprint"></pre></div>
         <input type="text" class="form-control" id="deployment_input">
     {% else %}
-        <div id="deployment_output"><pre class="prettyprint">{{ object.output }}</pre></div>
+        <div id="deployment_output">{{ object.output }}</div>
     {% endif %}
 {% endblock %}
 

--- a/fabric_bolt/projects/templates/projects/deployment_detail_socketio.html
+++ b/fabric_bolt/projects/templates/projects/deployment_detail_socketio.html
@@ -3,10 +3,10 @@
 
 {% block output %}
     {% if object.status == object.PENDING %}
-        <div id="deployment_output"><pre class="prettyprint"></pre></div>
+        <div id="deployment_output"><div class="outputcontainer"></div></div>
         <input type="text" class="form-control" id="deployment_input">
     {% else %}
-        <div id="deployment_output">{{ object.output }}</div>
+        <div id="deployment_output"><div class="outputcontainer">{{ object.output }}</div></div>
     {% endif %}
 {% endblock %}
 

--- a/fabric_bolt/projects/util.py
+++ b/fabric_bolt/projects/util.py
@@ -38,6 +38,12 @@ def update_project_git(project, cache_dir, repo_dir):
         )
 
 
+def setup_link_env_if_needed(repo_dir):
+    env_dir = os.path.join(repo_dir, 'env')
+    if not os.path.exists(env_dir):
+        os.symlink(os.environ.get('VIRTUAL_ENV'), env_dir)
+
+
 def setup_virtual_env_if_needed(repo_dir):
     env_dir = os.path.join(repo_dir, 'env')
     if not os.path.exists(env_dir):
@@ -63,7 +69,10 @@ def get_fabfile_path(project):
         repo_dir = os.path.join(cache_dir, slugify(project.name))
 
         update_project_git(project, cache_dir, repo_dir)
-        setup_virtual_env_if_needed(repo_dir)
+        if project.link_repo_env:
+            setup_link_env_if_needed(repo_dir)
+        else:
+            setup_virtual_env_if_needed(repo_dir)
         activate_loc = os.path.join(repo_dir, 'env', 'bin', 'activate')
 
         update_project_requirements(project, repo_dir, activate_loc)

--- a/fabric_bolt/projects/views.py
+++ b/fabric_bolt/projects/views.py
@@ -89,6 +89,7 @@ class ProjectCopy(MultipleGroupRequiredMixin, CreateView):
             initial.update({'name': '%s copy' % self.copy_object.name,
                             'description': self.copy_object.description,
                             'use_repo_fabfile': self.copy_object.use_repo_fabfile,
+                            'link_repo_env': self.copy_object.link_repo_env,
                             'fabfile_requirements': self.copy_object.fabfile_requirements,
                             'repo_url': self.copy_object.repo_url})
         return initial

--- a/fabric_bolt/projects/views.py
+++ b/fabric_bolt/projects/views.py
@@ -277,7 +277,7 @@ class ProjectConfigurationDelete(MultipleGroupRequiredMixin, DeleteView):
 
     def get_success_url(self):
         """Get the url depending on what type of configuration I deleted."""
-        
+
         if self.stage_id:
             url = reverse('projects_stage_view', args=(self.project_id, self.stage_id))
         else:
@@ -442,6 +442,7 @@ class DeploymentOutputStream(View):
         if get_task_details(self.object.stage.project, self.object.task.name) is None:
             return
 
+        preyield = True  # Use to balance <ul> tags upon error since we're streaming output
         try:
             process = subprocess.Popen(
                 build_command(self.object, self.request.session),
@@ -451,15 +452,27 @@ class DeploymentOutputStream(View):
             )
 
             all_output = ''
+            yield '<ul class="output">'
+            preyield = False
             while True:
                 nextline = process.stdout.readline()
-                if nextline == '' and process.poll() != None:
+                if nextline == '' and process.poll() is not None:
                     break
+
+                nextline = '<li class="outputline">{}</li>'.format(nextline)
+                if nextline.find('\x1b[32m') != -1:
+                    nextline = nextline.replace('\x1b[32m', '<ul class="outputgreen"><li class="outputline">')
+                elif nextline.find('\x1b[31m') != -1:
+                    nextline = nextline.replace('\x1b[31m', '<ul class="outputred"><li class="outputline">')
+                if nextline.find('\x1b[0m') != -1:
+                    nextline = nextline.replace('\x1b[0m', '</ul></li>')
 
                 all_output += nextline
 
-                yield '<span style="color:rgb(200, 200, 200);font-size: 14px;font-family: \'Helvetica Neue\', Helvetica, Arial, sans-serif;">{} </span><br /> {}'.format(nextline, ' '*1024)
+                yield nextline
                 sys.stdout.flush()
+            yield '</ul>'
+            preyield = True
 
             self.object.status = self.object.SUCCESS if process.returncode == 0 else self.object.FAILED
 
@@ -471,8 +484,11 @@ class DeploymentOutputStream(View):
             deployment_finished.send(self.object, deployment_id=self.object.pk)
 
         except Exception as e:
+            if not preyield:
+                yield '</ul>'
             message = "An error occurred: " + e.message
-            yield '<span style="color:rgb(200, 200, 200);font-size: 14px;font-family: \'Helvetica Neue\', Helvetica, Arial, sans-serif;">{} </span><br /> {}'.format(message, ' '*1024)
+            # yield '<span style="color:rgb(200, 200, 200);font-size: 14px;font-family: \'Helvetica Neue\', Helvetica, Arial, sans-serif;">{} </span><br /> {}'.format(message, ' '*1024)
+            yield '<span class="erroroutput">{} </span><br /> {}'.format(message, ' '*1024)
             yield '<span id="finished" style="display:none;">failed</span> {}'.format('*1024')
 
     def get(self, request, *args, **kwargs):

--- a/fabric_bolt/web_hooks/migrations/0001_initial.py
+++ b/fabric_bolt/web_hooks/migrations/0001_initial.py
@@ -37,7 +37,8 @@ class Migration(SchemaMigration):
             'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
             'repo_url': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
             'type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['projects.ProjectType']", 'null': 'True', 'blank': 'True'}),
-            'use_repo_fabfile': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+            'use_repo_fabfile': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'link_repo_env': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
         },
         u'projects.projecttype': {
             'Meta': {'object_name': 'ProjectType'},


### PR DESCRIPTION
This pull requests contains my virtual environment link pull request from earlier, but it also adds the ability to utilze "from fabric.colors import red, green"

In fabfile you can highlight console output by importing red and green colors and wrapping output with red() and green() def calls.

This pull request allows you to do the same thing in the web console by modifying the view to change the CSS class when it sees red or green terminal markers.

It also removes the need for &lt;pre&gt; tags and allows the object's stored output to look identical to the run time output.  It utilizes CSS, classes, and ul / li elements to make that possible.

Thus, a normal fabfile that utilizes "from fabric.colors import red, green" will now display identical colors in the fabric-bolt  web interface.