### PR TITLE
Adds SSH keyfile via command line

### DIFF
--- a/fabric_bolt/projects/tests.py
+++ b/fabric_bolt/projects/tests.py
@@ -259,6 +259,18 @@ class UtilTests(TestCase):
             '--abort-on-prompts --fabfile={}'.format(fabfile_path)
         )
 
+        deployment.stage.configuration_set.clear()
+        configuration = mommy.make(models.Configuration, key='key_filename', value='my_ssh_key')
+        deployment.stage.configuration_set.add(configuration)
+
+        command = build_command(deployment, {})
+
+        self.assertEqual(
+            command,
+            'fab test_env -i my_ssh_key '
+            '--abort-on-prompts --fabfile={}'.format(fabfile_path)
+        )
+
     def test_build_command_with_args(self):
         deployment = mommy.make(models.Deployment, task__name='test_env')
 

--- a/fabric_bolt/projects/util.py
+++ b/fabric_bolt/projects/util.py
@@ -9,7 +9,7 @@ from django.core.cache import cache
 # These options are passed to Fabric as: fab task --abort-on-prompts=True --user=root ...
 fabric_special_options = ['no_agent', 'forward-agent', 'config', 'disable-known-hosts', 'keepalive',
                           'password', 'parallel', 'no-pty', 'reject-unknown-hosts', 'skip-bad-hosts', 'timeout',
-                          'command-timeout', 'user', 'warn-only', 'pool-size']
+                          'command-timeout', 'user', 'warn-only', 'pool-size', 'key_filename']
 
 
 def check_output(command, shell=False):
@@ -247,7 +247,10 @@ def build_command(deployment, session, abort_on_prompts=True):
 
     if special_task_configs:
         for key in special_task_configs:
-            command += ' --' + get_key_value_string(command_to_config[key], configs[key])
+            if key == 'key_filename':
+                command += ' -i ' + configs[key].get_value()
+            else:
+                command += ' --' + get_key_value_string(command_to_config[key], configs[key])
 
     if abort_on_prompts:
         command += ' --abort-on-prompts'


### PR DESCRIPTION
This adds the SSH keyfile via command line, since the [env.key_filename](http://docs.fabfile.org/en/1.10/usage/env.html#key-filename) doesn't seem to work correctly.
It's a special case of the special cases (no `--` or `=`).