### PR TITLE
Remove protocol from gravatar url

### DIFF
--- a/fabric_bolt/accounts/models.py
+++ b/fabric_bolt/accounts/models.py
@@ -68,7 +68,7 @@ class DeployUser(AbstractEmailUser):
         """
         default = "mm"
 
-        gravatar_url = "http://www.gravatar.com/avatar/" + hashlib.md5(self.email.lower()).hexdigest() + "?"
+        gravatar_url = "//www.gravatar.com/avatar/" + hashlib.md5(self.email.lower()).hexdigest() + "?"
         gravatar_url += urllib.urlencode({'d': default, 's': str(size)})
 
         return gravatar_url

--- a/fabric_bolt/accounts/tests/test_general.py
+++ b/fabric_bolt/accounts/tests/test_general.py
@@ -94,7 +94,7 @@ class ModelsTest(TestCase):
     def test_user_gravatar(self):
         user = mommy.make(get_user_model(), email='email@example.com')
 
-        self.assertEqual(user.gravatar(30), 'http://www.gravatar.com/avatar/5658ffccee7f0ebfda2b226238b1eb6e?s=30&d=mm')
+        self.assertEqual(user.gravatar(30), '//www.gravatar.com/avatar/5658ffccee7f0ebfda2b226238b1eb6e?s=30&d=mm')
 
     def test_createsuperuser(self):
         user = get_user_model().objects.create_superuser(email='test@test.com', password='password')


### PR DESCRIPTION
When using HTTPS browsers give a warning because gravatar is loaded under HTTP. Removing the protocol will force the browser to load gravatar using either HTTP or HTTPS and remove the warning.