### PR TITLE
Fixed some problems that occurred when installing the development

### DIFF
--- a/fabric_bolt/core/settings/base.py
+++ b/fabric_bolt/core/settings/base.py
@@ -110,6 +110,7 @@ STATICFILES_FINDERS = (
 TEMPLATE_LOADERS = (
     'django.template.loaders.filesystem.Loader',
     'django.template.loaders.app_directories.Loader',
+    'django.template.loaders.eggs.Loader',
 )
 
 TEMPLATE_DIRS = (

--- a/fabric_bolt/projects/views.py
+++ b/fabric_bolt/projects/views.py
@@ -377,7 +377,7 @@ class DeploymentCreate(MultipleGroupRequiredMixin, CreateView):
             str_config_key = 'configuration_value_for_{}'.format(config.key)
 
             if config.data_type == config.BOOLEAN_TYPE:
-                field = BooleanField(widget=Select(choices=((False, 'False'), (True, 'True'))))
+                field = BooleanField(widget=Select(choices=((False, 'False'), (True, 'True'))), required=False)
                 field.coerce=lambda x: x == 'True',
             elif config.data_type == config.NUMBER_TYPE:
                 field = FloatField()

--- a/fabric_bolt/task_runners/base.py
+++ b/fabric_bolt/task_runners/base.py
@@ -39,9 +39,10 @@ class BaseTaskRunnerBackend(object):
         return self.special_options
 
     def check_output(self, command, shell=False):
+        # Need to use bash since some of the commands are prefixed with "source"
         executable = None
         if shell:
-            executable = getattr(settings, 'SHELL', '/bin/sh')
+            executable = getattr(settings, 'SHELL', '/bin/bash')
         return subprocess.check_output(command, shell=shell, executable=executable)
 
     def check_output_with_ssh_key(self, command):
@@ -54,6 +55,7 @@ class BaseTaskRunnerBackend(object):
             return self.check_output([command], shell=True)
 
     def update_project_git(self, project, cache_dir, repo_dir):
+
         if not os.path.exists(repo_dir):
             if not os.path.exists(cache_dir):
                 os.makedirs(cache_dir)
@@ -131,6 +133,10 @@ class BaseTaskRunnerBackend(object):
                         arguments.append(m.group(1))
                 else:
                     arguments.append(m.group(1))
+
+        # Class based Tasks have a 'self' argument - strip it.
+        if arguments and arguments[0] == 'self':
+            arguments = arguments[1:]
 
         return name, docstring, arguments
 

--- a/fabric_bolt/task_runners/basic/views.py
+++ b/fabric_bolt/task_runners/basic/views.py
@@ -29,7 +29,7 @@ class DeploymentOutputStream(StageSubPageMixin, View):
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 shell=True,
-                executable=getattr(settings, 'SHELL', '/bin/sh'),
+                executable=getattr(settings, 'SHELL', '/bin/bash'),
             )
 
             all_output = ''

--- a/fabric_bolt/utils/runner.py
+++ b/fabric_bolt/utils/runner.py
@@ -13,6 +13,9 @@ from fabric_bolt.core.settings.base import *
 
 CONF_ROOT = os.path.dirname(__file__)
 
+# See https://docs.djangoproject.com/en/1.8/ref/settings/#s-allowed-hosts
+ALLOWED_HOSTS=['*']
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,6 +12,7 @@ django-bootstrap-form==3.2
 croniter==0.3.12
 GitPython==1.0.2
 gevent-socketio==0.3.6
+gevent==1.2.1
 django-graphos==0.1.1
 django-activeurl==0.1.9
 requests==2.9.1
@@ -20,5 +21,6 @@ ansiconv==1.0.0
 channels==0.16
 autobahn==0.12.1
 twisted==15.5.0
+daphne==0.14.3
 six==1.10.0
 pycrypto==2.6.1

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ install_requires = [
     'croniter==0.3.12',
     'GitPython==1.0.2',
     'gevent-socketio==0.3.6',
+    'gevent==1.2.1',
     'django-graphos==0.1.1',
     'django-activeurl==0.1.9',
     'requests==2.9.1',
@@ -26,8 +27,10 @@ install_requires = [
     'channels==0.16',
     'autobahn==0.14.1',
     'twisted==15.5.0',
+    'daphne==0.14.3',
     'six==1.10.0',
     'ansiconv==1.0.0',
+    'pycrypto==2.6.1',
 ]
 
 dev_requires = [


### PR DESCRIPTION
Some issues arose when I installed the version of fabric-bolt directly from the git repository in January 2017.

1.  gevent was not installed
2.  daphne has a conflicting dependency. I pinned to an older version.
3.  pycrypto was not installed
4.  django_tables2 installed as a ziped egg, but the egg template loader was not configured.

Many of the shell commands issued by fabric-bolt source an environment file. These cannot be executed correctly using /bin/sh, the default shell. I changed the default shell to /bin/bash.

Generate the line for ALLOWED_HOSTS in the settings file. Otherwise novices have to work through the documentation.

If using class based fabric tasks, the fabric-bolt tried to send values for the 'self' parameter, which did not work.